### PR TITLE
Bump MSRV to 1.63

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         # When updating this, the reminder to update the minimum supported
         # Rust version in Cargo.toml.
-        rust: ['1.48']
+        rust: ['1.63']
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["asynchronous"]
 # when updating rust-version:
 # - update ci.yml
 # - update readme.md
-rust-version = "1.48.0"
+rust-version = "1.63.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Unlike other `async` runtimes, `unsend` deliberately avoids providing certain po
 
 ## Minimum Supported Rust Version
 
-The Minimum Supported Rust Version (MSRV) of this crate is **1.48**. As a **tentative** policy, the MSRV will not advance past the [current Rust version provided by Debian Stable](https://packages.debian.org/stable/rust/rustc). At the time of writing, this version of Rust is *1.48*. However, the MSRV may be advanced further in the event of a major ecosystem shift or a security vulnerability.
+The Minimum Supported Rust Version (MSRV) of this crate is **1.63**. As a **tentative** policy, the MSRV will not advance past the [current Rust version provided by Debian Stable](https://packages.debian.org/stable/rust/rustc). At the time of writing, this version of Rust is *1.63*. However, the MSRV may be advanced further in the event of a major ecosystem shift or a security vulnerability.
 
 ## Examples
 


### PR DESCRIPTION
- [x] Tested on all platforms affected by this change
- [x] Signed the [Contribution License Agreement (CLA)](https://cla-assistant.io/notgull/unsend)